### PR TITLE
Use the with keyword for the JSON import attribute

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -3,7 +3,7 @@ import commonjs from '@rollup/plugin-commonjs'
 import nodeResolve from '@rollup/plugin-node-resolve'
 import replace from '@rollup/plugin-replace'
 import terser from '@rollup/plugin-terser'
-import pkg from './package.json' assert { type: 'json' }
+import pkg from './package.json' with { type: 'json' }
 
 const CJS_DEV = 'CJS_DEV'
 const CJS_PROD = 'CJS_PROD'


### PR DESCRIPTION
`rollup.config.mjs` imported `package.json` with `assert { type: 'json' }`. Node 22 removed that spelling in favour of `with`, and `.nvmrc` tracks `lts/*`, so CI walked onto Node 22 and the config stopped parsing — `SyntaxError: Unexpected identifier 'assert'`, which fails `bundle`, which fails `build`, which fails the whole `test` script.

Every CI run on this repo has been red since then, including every Renovate PR, which is why the dependency updates have been piling up rather than landing. One keyword is the entire fix: `npm test` passes locally on Node 24 with this change and nothing else.